### PR TITLE
wcコマンドを作成・追加

### DIFF
--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -3,7 +3,7 @@
 
 require 'optparse'
 
-DEFAULT_WIDTH = 8
+PRINTING_WIDTH = 8
 
 def main
   options = ARGV.getopts('lwc')
@@ -18,20 +18,15 @@ def print_pipelined_input(options)
   file_size = count_bytesize(input_data_lines)
 
   input_data_properties = [{ 'line_count' => line_count, 'word_count' => word_count, 'file_size' => file_size, 'file_name' => '' }]
-  largest_total_count_digits = [line_count, word_count, file_size].max.to_s.size
-  width = calc_width(largest_total_count_digits)
 
-  print_files_own_properties(input_data_properties, width, options)
+  print_files_own_properties(input_data_properties, options)
 end
 
 def print_specified_files(files, options)
   files_info = format_files_own_properties(files)
 
-  largest_total_count_digits = files_info[:total_counts].values.max.to_s.size
-  width = calc_width(largest_total_count_digits)
-
-  print_files_own_properties(files_info[:unique_properties], width, options)
-  print_total_counts(files_info[:total_counts], width, options) if files.size > 1
+  print_files_own_properties(files_info[:unique_properties], options)
+  print_total_counts(files_info[:total_counts], options) if files.size > 1
 end
 
 def format_files_own_properties(files)
@@ -75,28 +70,24 @@ def count_bytesize(lines)
   lines.join.bytesize
 end
 
-def calc_width(num)
-  num + 1 > DEFAULT_WIDTH ? num + 1 : DEFAULT_WIDTH
-end
-
-def print_files_own_properties(files_properties, width, options)
+def print_files_own_properties(files_properties, options)
   files_properties.each do |file_properties|
-    output = arrange_output_line(file_properties, width, options)
+    output = arrange_output_line(file_properties, options)
     puts output + " #{file_properties['file_name']}"
   end
 end
 
-def print_total_counts(total_counts, width, options)
-  output = arrange_output_line(total_counts, width, options)
+def print_total_counts(total_counts, options)
+  output = arrange_output_line(total_counts, options)
   puts "#{output} total"
 end
 
-def arrange_output_line(properties, width, options)
+def arrange_output_line(properties, options)
   is_option_none = options.values.none?
   output = ''
-  output += properties['line_count'].to_s.rjust(width) if options['l'] || is_option_none
-  output += properties['word_count'].to_s.rjust(width) if options['w'] || is_option_none
-  output += properties['file_size'].to_s.rjust(width) if options['c'] || is_option_none
+  output += properties['line_count'].to_s.rjust(PRINTING_WIDTH) if options['l'] || is_option_none
+  output += properties['word_count'].to_s.rjust(PRINTING_WIDTH) if options['w'] || is_option_none
+  output += properties['file_size'].to_s.rjust(PRINTING_WIDTH) if options['c'] || is_option_none
   output
 end
 

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -18,8 +18,8 @@ def print_from_stdin(options)
   file_size = count_bytesize(input_data_lines)
 
   lines_words_sizes = [{ 'lines_num' => lines_num, 'words_num' => words_num, 'file_size' => file_size, 'file_name' => '' }]
-  width = [lines_num, words_num, file_size].max.to_s.size
-  width = width + 1 > DEFAULT_WIDTH ? width + 1 : DEFAULT_WIDTH
+  largest_total_num_digits = [lines_num, words_num, file_size].max.to_s.size
+  width = calc_width(largest_total_num_digits)
 
   print_info(lines_words_sizes, width, options)
 end
@@ -27,7 +27,9 @@ end
 def print_from_args(files, options)
   files_info = format_files_info(files)
 
-  width = calc_width(files_info[:total_nums])
+  largest_total_num_digits = files_info[:total_nums].values.max.to_s.size
+  width = calc_width(largest_total_num_digits)
+
   print_info(files_info[:lines_words_sizes], width, options)
   print_total(files_info[:total_nums], width, options) if files.size > 1
 end
@@ -45,9 +47,14 @@ def format_files_info(files)
   total_size = file_sizes.sum
 
   lines_words_sizes = [lines_nums, words_nums, file_sizes, files].transpose
-  lines_words_sizes_keys = %w[lines_num words_num file_size file_name]
+  # lines_words_sizes_keys = %w[lines_num words_num file_size file_name]
+  # formatted_3_elements_info =
+  #   lines_words_sizes.map { |file_info| [lines_words_sizes_keys, file_info].transpose.to_h }
+  # TODO: 下記の修正の方向性が正しいか質問
   formatted_3_elements_info =
-    lines_words_sizes.map { |file_info| [lines_words_sizes_keys, file_info].transpose.to_h }
+    lines_words_sizes.map do |file_info|
+      { 'lines_num' => file_info[0], 'words_num' => file_info[1], 'file_size' => file_info[2], 'file_name' => file_info[3] }
+    end
 
   total_nums = [total_lines_nums, total_words_nums, total_size]
   total_nums_keys = %w[lines_num words_num file_size]
@@ -73,30 +80,27 @@ def count_bytesize(lines)
   lines.join.bytesize
 end
 
-def calc_width(nums)
-  width = nums.values.map { |num| num.to_s.size }.max
-  width + 1 > DEFAULT_WIDTH ? width + 1 : DEFAULT_WIDTH
+def calc_width(num)
+  num + 1 > DEFAULT_WIDTH ? num + 1 : DEFAULT_WIDTH
 end
 
 def print_info(files_data, width, options)
-  output = ''
-  is_option_none = options.values.none?
   files_data.each do |file_data|
-    output = arrange_each_file(output, file_data, width, options, is_option_none)
-    output += " #{file_data['file_name']}\n"
+    output = arrange_each_file(file_data, width, options)
+    output += " #{file_data['file_name']}"
+    puts output
   end
-  print output
 end
 
 def print_total(total_nums, width, options)
-  output = ''
-  is_option_none = options.values.none?
-  output = arrange_each_file(output, total_nums, width, options, is_option_none)
-  output += " total\n"
-  print output
+  output = arrange_each_file(total_nums, width, options)
+  output += ' total'
+  puts output
 end
 
-def arrange_each_file(output, file_data, width, options, is_option_none)
+def arrange_each_file(file_data, width, options)
+  is_option_none = options.values.none?
+  output = ''
   output += file_data['lines_num'].to_s.rjust(width) if options['l'] || is_option_none
   output += file_data['words_num'].to_s.rjust(width) if options['w'] || is_option_none
   output += file_data['file_size'].to_s.rjust(width) if options['c'] || is_option_none

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'optparse'
+require 'debug'
 
 PRINTING_WIDTH = 8
 
@@ -17,7 +18,7 @@ def print_pipelined_input(options)
   word_count = count_words(input_data_lines)
   file_size = count_bytesize(input_data_lines)
 
-  input_data_properties = [{ 'line_count' => line_count, 'word_count' => word_count, 'file_size' => file_size, 'file_name' => '' }]
+  input_data_properties = [{ line_count:, word_count:, file_size:, file_name: '' }]
 
   print_files_own_properties(input_data_properties, options)
 end
@@ -25,36 +26,60 @@ end
 def print_specified_files(files, options)
   files_info = format_files_own_properties(files)
 
-  print_files_own_properties(files_info[:unique_properties], options)
-  print_total_counts(files_info[:total_counts], options) if files.size > 1
+  print_files_own_properties(files_info, options)
+  # print_total_counts(files_info[:total_counts], options) if files.size > 1
 end
 
 def format_files_own_properties(files)
-  all_files_lines = files.map { |file| File.open(file, &:readlines) }
+  # all_files_lines = files.map { |file| File.open(file, &:readlines) }
 
-  line_counts = all_files_lines.map { |file_lines| count_lines(file_lines) }
-  total_line_count = line_counts.sum
+  # line_counts = all_files_lines.map { |file_lines| count_lines(file_lines) }
+  # total_line_count = line_counts.sum
 
-  word_counts = all_files_lines.map { |file_lines| count_words(file_lines) }
-  total_word_count = word_counts.sum
+  # word_counts = all_files_lines.map { |file_lines| count_words(file_lines) }
+  # total_word_count = word_counts.sum
 
-  file_sizes = all_files_lines.map { |file_lines| count_bytesize(file_lines) }
-  total_size = file_sizes.sum
+  # file_sizes = all_files_lines.map { |file_lines| count_bytesize(file_lines) }
+  # total_size = file_sizes.sum
 
-  files_own_properties_sets = [line_counts, word_counts, file_sizes, files].transpose
   formatted_files_own_properties_sets =
-    files_own_properties_sets.map do |file_properties|
-      { 'line_count' => file_properties[0], 'word_count' => file_properties[1], 'file_size' => file_properties[2], 'file_name' => file_properties[3] }
+    files.map do |file|
+      file_lines = File.open(file, &:readlines)
+      line_count = count_lines(file_lines)
+      word_count = count_words(file_lines)
+      file_size = count_bytesize(file_lines)
+      file_name = file
+      { line_count:, word_count:, file_size:, file_name: }
     end
 
-  total_counts = [total_line_count, total_word_count, total_size]
-  total_counts_keys = %w[line_count word_count file_size]
-  formatted_total_counts = [total_counts_keys, total_counts].transpose.to_h
+  # files_own_properties_sets = [line_counts, word_counts, file_sizes, files].transpose
+  # formatted_files_own_properties_sets =
+  #   files_own_properties_sets.map do |file_properties|
+  #     { 'line_count' => file_properties[0], 'word_count' => file_properties[1], 'file_size' => file_properties[2], 'file_name' => file_properties[3] }
+  #   end
+  
+  if files.size > 1
+    line_count = 0
+    word_count = 0
+    file_size = 0
+    file_name = 'total'
+    formatted_files_own_properties_sets.each do |file|
+      line_count += file[:line_count]
+      word_count += file[:word_count]
+      file_size += file[:file_size]
+    end
+    formatted_files_own_properties_sets << { line_count:, word_count:, file_size:, file_name: }
+  end
 
-  {
-    unique_properties: formatted_files_own_properties_sets,
-    total_counts: formatted_total_counts
-  }
+  # total_counts = [total_line_count, total_word_count, total_size]
+  # total_counts_keys = %w[line_count word_count file_size]
+  # formatted_total_counts = [total_counts_keys, total_counts].transpose.to_h
+
+  # {
+  #   unique_properties: formatted_files_own_properties_sets,
+  #   total_counts: formatted_total_counts
+  # }
+  formatted_files_own_properties_sets
 end
 
 def count_lines(lines)
@@ -73,21 +98,16 @@ end
 def print_files_own_properties(files_properties, options)
   files_properties.each do |file_properties|
     output = arrange_output_line(file_properties, options)
-    puts output + " #{file_properties['file_name']}"
+    puts output + " #{file_properties[:file_name]}"
   end
-end
-
-def print_total_counts(total_counts, options)
-  output = arrange_output_line(total_counts, options)
-  puts "#{output} total"
 end
 
 def arrange_output_line(properties, options)
   is_option_none = options.values.none?
   output = ''
-  output += properties['line_count'].to_s.rjust(PRINTING_WIDTH) if options['l'] || is_option_none
-  output += properties['word_count'].to_s.rjust(PRINTING_WIDTH) if options['w'] || is_option_none
-  output += properties['file_size'].to_s.rjust(PRINTING_WIDTH) if options['c'] || is_option_none
+  output += properties[:line_count].to_s.rjust(PRINTING_WIDTH) if options['l'] || is_option_none
+  output += properties[:word_count].to_s.rjust(PRINTING_WIDTH) if options['w'] || is_option_none
+  output += properties[:file_size].to_s.rjust(PRINTING_WIDTH) if options['c'] || is_option_none
   output
 end
 

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -7,62 +7,58 @@ DEFAULT_WIDTH = 8
 
 def main
   options = ARGV.getopts('lwc')
-  ARGV.none? ? print_from_stdin(options) : print_from_args(ARGV, options)
+  ARGV.none? ? print_pipelined_input(options) : print_specified_files(ARGV, options)
 end
 
-def print_from_stdin(options)
+def print_pipelined_input(options)
   input_data_lines = $stdin.readlines
 
-  lines_num = count_lines(input_data_lines)
-  words_num = count_words(input_data_lines)
+  line_count = count_lines(input_data_lines)
+  word_count = count_words(input_data_lines)
   file_size = count_bytesize(input_data_lines)
 
-  lines_words_sizes = [{ 'lines_num' => lines_num, 'words_num' => words_num, 'file_size' => file_size, 'file_name' => '' }]
-  largest_total_num_digits = [lines_num, words_num, file_size].max.to_s.size
-  width = calc_width(largest_total_num_digits)
+  input_data_properties = [{ 'line_count' => line_count, 'word_count' => word_count, 'file_size' => file_size, 'file_name' => '' }]
+  largest_total_count_digits = [line_count, word_count, file_size].max.to_s.size
+  width = calc_width(largest_total_count_digits)
 
-  print_info(lines_words_sizes, width, options)
+  print_files_own_properties(input_data_properties, width, options)
 end
 
-def print_from_args(files, options)
-  files_info = format_files_info(files)
+def print_specified_files(files, options)
+  files_info = format_files_own_properties(files)
 
-  largest_total_num_digits = files_info[:total_nums].values.max.to_s.size
-  width = calc_width(largest_total_num_digits)
+  largest_total_count_digits = files_info[:total_counts].values.max.to_s.size
+  width = calc_width(largest_total_count_digits)
 
-  print_info(files_info[:lines_words_sizes], width, options)
-  print_total(files_info[:total_nums], width, options) if files.size > 1
+  print_files_own_properties(files_info[:unique_properties], width, options)
+  print_total_counts(files_info[:total_counts], width, options) if files.size > 1
 end
 
-def format_files_info(files)
+def format_files_own_properties(files)
   all_files_lines = files.map { |file| File.open(file, &:readlines) }
 
-  lines_nums = all_files_lines.map { |file_lines| count_lines(file_lines) }
-  total_lines_nums = lines_nums.sum
+  line_counts = all_files_lines.map { |file_lines| count_lines(file_lines) }
+  total_line_count = line_counts.sum
 
-  words_nums = all_files_lines.map { |file_lines| count_words(file_lines) }
-  total_words_nums = words_nums.sum
+  word_counts = all_files_lines.map { |file_lines| count_words(file_lines) }
+  total_word_count = word_counts.sum
 
   file_sizes = all_files_lines.map { |file_lines| count_bytesize(file_lines) }
   total_size = file_sizes.sum
 
-  lines_words_sizes = [lines_nums, words_nums, file_sizes, files].transpose
-  # lines_words_sizes_keys = %w[lines_num words_num file_size file_name]
-  # formatted_3_elements_info =
-  #   lines_words_sizes.map { |file_info| [lines_words_sizes_keys, file_info].transpose.to_h }
-  # TODO: 下記の修正の方向性が正しいか質問
-  formatted_3_elements_info =
-    lines_words_sizes.map do |file_info|
-      { 'lines_num' => file_info[0], 'words_num' => file_info[1], 'file_size' => file_info[2], 'file_name' => file_info[3] }
+  files_own_properties_sets = [line_counts, word_counts, file_sizes, files].transpose
+  formatted_files_own_properties_sets =
+    files_own_properties_sets.map do |file_properties|
+      { 'line_count' => file_properties[0], 'word_count' => file_properties[1], 'file_size' => file_properties[2], 'file_name' => file_properties[3] }
     end
 
-  total_nums = [total_lines_nums, total_words_nums, total_size]
-  total_nums_keys = %w[lines_num words_num file_size]
-  formatted_total_nums = [total_nums_keys, total_nums].transpose.to_h
+  total_counts = [total_line_count, total_word_count, total_size]
+  total_counts_keys = %w[line_count word_count file_size]
+  formatted_total_counts = [total_counts_keys, total_counts].transpose.to_h
 
   {
-    lines_words_sizes: formatted_3_elements_info,
-    total_nums: formatted_total_nums
+    unique_properties: formatted_files_own_properties_sets,
+    total_counts: formatted_total_counts
   }
 end
 
@@ -84,26 +80,24 @@ def calc_width(num)
   num + 1 > DEFAULT_WIDTH ? num + 1 : DEFAULT_WIDTH
 end
 
-def print_info(files_data, width, options)
-  files_data.each do |file_data|
-    output = arrange_each_file(file_data, width, options)
-    output += " #{file_data['file_name']}"
-    puts output
+def print_files_own_properties(files_properties, width, options)
+  files_properties.each do |file_properties|
+    output = arrange_output_line(file_properties, width, options)
+    puts output + " #{file_properties['file_name']}"
   end
 end
 
-def print_total(total_nums, width, options)
-  output = arrange_each_file(total_nums, width, options)
-  output += ' total'
-  puts output
+def print_total_counts(total_counts, width, options)
+  output = arrange_output_line(total_counts, width, options)
+  puts "#{output} total"
 end
 
-def arrange_each_file(file_data, width, options)
+def arrange_output_line(properties, width, options)
   is_option_none = options.values.none?
   output = ''
-  output += file_data['lines_num'].to_s.rjust(width) if options['l'] || is_option_none
-  output += file_data['words_num'].to_s.rjust(width) if options['w'] || is_option_none
-  output += file_data['file_size'].to_s.rjust(width) if options['c'] || is_option_none
+  output += properties['line_count'].to_s.rjust(width) if options['l'] || is_option_none
+  output += properties['word_count'].to_s.rjust(width) if options['w'] || is_option_none
+  output += properties['file_size'].to_s.rjust(width) if options['c'] || is_option_none
   output
 end
 

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -11,15 +11,15 @@ def main
 end
 
 def print_pipelined_input(options)
-  input_data_lines = $stdin.readlines
+  stdin_lines = $stdin.readlines
 
-  line_count = count_lines(input_data_lines)
-  word_count = count_words(input_data_lines)
-  bytesize = count_bytesize(input_data_lines)
+  line_count = count_lines(stdin_lines)
+  word_count = count_words(stdin_lines)
+  bytesize = count_bytesize(stdin_lines)
 
-  input_data_props = [{ line_count:, word_count:, bytesize:, file_name: '' }]
+  stdin_props = [{ line_count:, word_count:, bytesize:, file_name: '' }]
 
-  print_file_props(input_data_props, options)
+  print_file_props(stdin_props, options)
 end
 
 def print_specified_files(files, options)

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -35,15 +35,15 @@ def print_specified_files(files, options)
   print_file_props(file_props, options)
 end
 
-def format_file_prop(file_lines, total_prop_count = nil)
+def format_file_prop(file_lines, total_file_prop_count = nil)
   line_count = count_lines(file_lines)
   word_count = count_words(file_lines)
   bytesize = count_bytesize(file_lines)
 
-  unless total_prop_count.nil?
-    total_prop_count[:line_count] += line_count
-    total_prop_count[:word_count] += word_count
-    total_prop_count[:bytesize] += bytesize
+  unless total_file_prop_count.nil?
+    total_file_prop_count[:line_count] += line_count
+    total_file_prop_count[:word_count] += word_count
+    total_file_prop_count[:bytesize] += bytesize
   end
 
   { line_count:, word_count:, bytesize: }

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -77,8 +77,7 @@ end
 
 def lines_num(lines)
   lines_num = lines.size
-  lines_num -= 1 unless lines.last.end_with?("\n")
-  lines_num = 0 if lines.none?
+  lines_num -= 1 unless lines.none? || lines.last.end_with?("\n")
   lines_num
 end
 

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -64,8 +64,7 @@ end
 
 def count_lines(lines)
   lines_num = lines.size
-  lines_num -= 1 unless lines.none? || lines.last.end_with?("\n")
-  lines_num
+  lines.none? || lines.last.end_with?("\n") ? lines_num : lines_num - 1
 end
 
 def count_words(lines)

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -46,7 +46,7 @@ def print_from_args(args)
     print_total(total_nums, width)
     print " total\n"
   else
-    print_info(formatted_files, width)
+    print_info(formatted_info, width)
   end
 end
 

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require 'optparse'
-require 'debug'
 
 PRINTING_WIDTH = 8
 
@@ -27,20 +26,9 @@ def print_specified_files(files, options)
   files_info = format_files_own_properties(files)
 
   print_files_own_properties(files_info, options)
-  # print_total_counts(files_info[:total_counts], options) if files.size > 1
 end
 
 def format_files_own_properties(files)
-  # all_files_lines = files.map { |file| File.open(file, &:readlines) }
-
-  # line_counts = all_files_lines.map { |file_lines| count_lines(file_lines) }
-  # total_line_count = line_counts.sum
-
-  # word_counts = all_files_lines.map { |file_lines| count_words(file_lines) }
-  # total_word_count = word_counts.sum
-
-  # file_sizes = all_files_lines.map { |file_lines| count_bytesize(file_lines) }
-  # total_size = file_sizes.sum
 
   formatted_files_own_properties_sets =
     files.map do |file|
@@ -51,12 +39,6 @@ def format_files_own_properties(files)
       file_name = file
       { line_count:, word_count:, file_size:, file_name: }
     end
-
-  # files_own_properties_sets = [line_counts, word_counts, file_sizes, files].transpose
-  # formatted_files_own_properties_sets =
-  #   files_own_properties_sets.map do |file_properties|
-  #     { 'line_count' => file_properties[0], 'word_count' => file_properties[1], 'file_size' => file_properties[2], 'file_name' => file_properties[3] }
-  #   end
   
   if files.size > 1
     line_count = 0
@@ -71,14 +53,6 @@ def format_files_own_properties(files)
     formatted_files_own_properties_sets << { line_count:, word_count:, file_size:, file_name: }
   end
 
-  # total_counts = [total_line_count, total_word_count, total_size]
-  # total_counts_keys = %w[line_count word_count file_size]
-  # formatted_total_counts = [total_counts_keys, total_counts].transpose.to_h
-
-  # {
-  #   unique_properties: formatted_files_own_properties_sets,
-  #   total_counts: formatted_total_counts
-  # }
   formatted_files_own_properties_sets
 end
 

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -14,9 +14,9 @@ def print_from_stdin(options)
   input_data = $stdin.read
   lines = input_data.split("\n")
 
-  lines_num = lines.size.to_s
-  words_num = lines.map { |line| line.split.size }.sum.to_s
-  file_size = input_data.bytesize.to_s
+  lines_num = lines.size
+  words_num = lines.map { |line| line.split.size }.sum
+  file_size = input_data.bytesize
   total_nums = [lines_num, words_num, file_size]
 
   width = calc_width(total_nums)
@@ -27,18 +27,18 @@ end
 
 def print_from_args(files, options)
   lines_nums = calc_lines_nums(files)
-  total_lines_nums = lines_nums.sum.to_s
+  total_lines_nums = lines_nums.sum
 
   words_nums = calc_words_nums(files)
-  total_words_nums = words_nums.sum.to_s
+  total_words_nums = words_nums.sum
 
   file_sizes = calc_sizes(files)
-  total_size = file_sizes.sum.to_s
+  total_size = file_sizes.sum
 
   total_nums = [total_lines_nums, total_words_nums, total_size]
   width = calc_width(total_nums)
 
-  files_info = [lines_nums.map(&:to_s), words_nums.map(&:to_s), file_sizes.map(&:to_s), files]
+  files_info = [lines_nums, words_nums, file_sizes, files]
   formatted_info = files_info.transpose
 
   if files.size > 1
@@ -79,7 +79,7 @@ def lines_num(lines)
 end
 
 def calc_width(nums)
-  width = nums.map(&:size).max
+  width = nums.map { |num| num.to_s.size }.max
   width + 1 > DEFAULT_WIDTH ? width + 1 : DEFAULT_WIDTH
 end
 
@@ -87,9 +87,9 @@ def print_info(files, width, options)
   output = ''
   is_option_none = options.values.none?
   files.each do |file|
-    output += file[0].rjust(width) if options['l'] || is_option_none
-    output += file[1].rjust(width) if options['w'] || is_option_none
-    output += file[2].rjust(width) if options['c'] || is_option_none
+    output += file[0].to_s.rjust(width) if options['l'] || is_option_none
+    output += file[1].to_s.rjust(width) if options['w'] || is_option_none
+    output += file[2].to_s.rjust(width) if options['c'] || is_option_none
     output += " #{file[3]}\n"
   end
   print output
@@ -98,9 +98,9 @@ end
 def print_total(total_nums, width, options)
   output = ''
   is_option_none = options.values.none?
-  output += total_nums[0].rjust(width) if options['l'] || is_option_none
-  output += total_nums[1].rjust(width) if options['w'] || is_option_none
-  output += total_nums[2].rjust(width) if options['c'] || is_option_none
+  output += total_nums[0].to_s.rjust(width) if options['l'] || is_option_none
+  output += total_nums[1].to_s.rjust(width) if options['w'] || is_option_none
+  output += total_nums[2].to_s.rjust(width) if options['c'] || is_option_none
   print output
 end
 

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -25,23 +25,23 @@ def print_from_stdin
   print "\n"
 end
 
-def print_from_args(args)
-  nums_of_lines = calc_nums_of_lines(args)
+def print_from_args(files)
+  nums_of_lines = calc_nums_of_lines(files)
   total_nums_of_lines = nums_of_lines.sum.to_s
 
-  nums_of_words = calc_nums_of_words(args)
+  nums_of_words = calc_nums_of_words(files)
   total_nums_of_words = nums_of_words.sum.to_s
 
-  file_sizes = calc_sizes(args)
+  file_sizes = calc_sizes(files)
   total_size = file_sizes.sum.to_s
 
   total_nums = [total_nums_of_lines, total_nums_of_words, total_size]
   width = calc_width(total_nums)
 
-  files_info = [nums_of_lines.map(&:to_s), nums_of_words.map(&:to_s), file_sizes.map(&:to_s), args]
+  files_info = [nums_of_lines.map(&:to_s), nums_of_words.map(&:to_s), file_sizes.map(&:to_s), files]
   formatted_info = files_info.transpose
 
-  if args.size > 1
+  if files.size > 1
     print_info(formatted_info, width)
     print_total(total_nums, width)
     print " total\n"

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -4,13 +4,13 @@
 require 'optparse'
 
 DEFAULT_WIDTH = 8
-OPTIONS = ARGV.getopts('lwc')
 
 def main
-  ARGV.none? ? print_from_stdin : print_from_args(ARGV)
+  options = ARGV.getopts('lwc')
+  ARGV.none? ? print_from_stdin(options) : print_from_args(ARGV, options)
 end
 
-def print_from_stdin
+def print_from_stdin(options)
   input_data = $stdin.read
   lines = input_data.split("\n")
 
@@ -21,11 +21,11 @@ def print_from_stdin
 
   width = calc_width(total_nums)
 
-  print_total(total_nums, width)
+  print_total(total_nums, width, options)
   print "\n"
 end
 
-def print_from_args(files)
+def print_from_args(files, options)
   lines_nums = calc_lines_nums(files)
   total_lines_nums = lines_nums.sum.to_s
 
@@ -42,11 +42,11 @@ def print_from_args(files)
   formatted_info = files_info.transpose
 
   if files.size > 1
-    print_info(formatted_info, width)
-    print_total(total_nums, width)
+    print_info(formatted_info, width, options)
+    print_total(total_nums, width, options)
     print " total\n"
   else
-    print_info(formatted_info, width)
+    print_info(formatted_info, width, options)
   end
 end
 
@@ -83,24 +83,24 @@ def calc_width(nums)
   width + 1 > DEFAULT_WIDTH ? width + 1 : DEFAULT_WIDTH
 end
 
-def print_info(files, width)
+def print_info(files, width, options)
   output = ''
-  is_option_none = OPTIONS.values.none?
+  is_option_none = options.values.none?
   files.each do |file|
-    output += file[0].rjust(width) if OPTIONS['l'] || is_option_none
-    output += file[1].rjust(width) if OPTIONS['w'] || is_option_none
-    output += file[2].rjust(width) if OPTIONS['c'] || is_option_none
+    output += file[0].rjust(width) if options['l'] || is_option_none
+    output += file[1].rjust(width) if options['w'] || is_option_none
+    output += file[2].rjust(width) if options['c'] || is_option_none
     output += " #{file[3]}\n"
   end
   print output
 end
 
-def print_total(total_nums, width)
+def print_total(total_nums, width, options)
   output = ''
-  is_option_none = OPTIONS.values.none?
-  output += total_nums[0].rjust(width) if OPTIONS['l'] || is_option_none
-  output += total_nums[1].rjust(width) if OPTIONS['w'] || is_option_none
-  output += total_nums[2].rjust(width) if OPTIONS['c'] || is_option_none
+  is_option_none = options.values.none?
+  output += total_nums[0].rjust(width) if options['l'] || is_option_none
+  output += total_nums[1].rjust(width) if options['w'] || is_option_none
+  output += total_nums[2].rjust(width) if options['c'] || is_option_none
   print output
 end
 

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -13,9 +13,9 @@ end
 def print_from_stdin(options)
   input_data_lines = $stdin.readlines
 
-  lines_num = lines_num(input_data_lines)
-  words_num = input_data_lines.sum { |line| line.split.size }
-  file_size = input_data_lines.join.bytesize
+  lines_num = count_lines(input_data_lines)
+  words_num = count_words(input_data_lines)
+  file_size = count_bytesize(input_data_lines)
   total_nums = { 'total_lines' => lines_num, 'total_words' => words_num, 'total_size' => file_size }
 
   print_total(total_nums, options)
@@ -37,23 +37,23 @@ end
 def format_files_info(files)
   all_files_lines = files.map { |file| File.open(file, &:readlines) }
 
-  lines_nums = calc_lines_nums(all_files_lines)
+  lines_nums = all_files_lines.map { |file_lines| count_lines(file_lines) }
   total_lines_nums = lines_nums.sum
 
-  words_nums = calc_words_nums(all_files_lines)
+  words_nums = all_files_lines.map { |file_lines| count_words(file_lines) }
   total_words_nums = words_nums.sum
 
-  file_sizes = calc_sizes(all_files_lines)
+  file_sizes = all_files_lines.map { |file_lines| count_bytesize(file_lines) }
   total_size = file_sizes.sum
 
   lines_words_sizes = [lines_nums, words_nums, file_sizes, files].transpose
-  keys = %w[lines_num words_num file_size file_name]
+  lines_words_sizes_keys = %w[lines_num words_num file_size file_name]
   formatted_3_elemetnts_info =
-    lines_words_sizes.map { |info| [keys, info].transpose.to_h }
+    lines_words_sizes.map { |file_info| [lines_words_sizes_keys, file_info].transpose.to_h }
 
   total_nums = [total_lines_nums, total_words_nums, total_size]
-  keys = %w[total_lines total_words total_size]
-  formatted_total_nums = [keys, total_nums].transpose.to_h
+  total_nums_keys = %w[total_lines total_words total_size]
+  formatted_total_nums = [total_nums_keys, total_nums].transpose.to_h
 
   {
     lines_words_sizes: formatted_3_elemetnts_info,
@@ -61,24 +61,18 @@ def format_files_info(files)
   }
 end
 
-def calc_lines_nums(files_lines)
-  files_lines.map { |file_lines| lines_num(file_lines) }
-end
-
-def calc_words_nums(files_lines)
-  files_lines.map do |file_lines|
-    file_lines.sum { |line| line.split.size }
-  end
-end
-
-def calc_sizes(files_lines)
-  files_lines.map { |file_lines| file_lines.join.bytesize }
-end
-
-def lines_num(lines)
+def count_lines(lines)
   lines_num = lines.size
   lines_num -= 1 unless lines.none? || lines.last.end_with?("\n")
   lines_num
+end
+
+def count_words(lines)
+  lines.sum { |line| line.split.size }
+end
+
+def count_bytesize(lines)
+  lines.join.bytesize
 end
 
 def calc_width(nums)

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -13,38 +13,40 @@ end
 def print_pipelined_input(options)
   stdin_lines = $stdin.readlines
 
-  line_count = count_lines(stdin_lines)
-  word_count = count_words(stdin_lines)
-  bytesize = count_bytesize(stdin_lines)
+  stdin_prop = format_file_prop(stdin_lines)
+  stdin_prop[:file_name] = ''
 
-  stdin_props = [{ line_count:, word_count:, bytesize:, file_name: '' }]
-
-  print_file_props(stdin_props, options)
+  print_file_props([stdin_prop], options)
 end
 
 def print_specified_files(files, options)
+  total_file_prop_count = { line_count: 0, word_count: 0, bytesize: 0, file_name: 'total' }
+
   file_props =
     files.map do |file|
       file_lines = File.open(file, &:readlines)
-      line_count = count_lines(file_lines)
-      word_count = count_words(file_lines)
-      bytesize = count_bytesize(file_lines)
-      { line_count:, word_count:, bytesize:, file_name: file }
+      file_prop = format_file_prop(file_lines, total_file_prop_count)
+      file_prop[:file_name] = file
+      file_prop
     end
 
-  if files.size > 1
-    line_count = 0
-    word_count = 0
-    bytesize = 0
-    file_props.each do |file_prop|
-      line_count += file_prop[:line_count]
-      word_count += file_prop[:word_count]
-      bytesize += file_prop[:bytesize]
-    end
-    file_props << { line_count:, word_count:, bytesize:, file_name: 'total' }
-  end
+  file_props << total_file_prop_count if files.size > 1
 
   print_file_props(file_props, options)
+end
+
+def format_file_prop(file_lines, total_prop_count = nil)
+  line_count = count_lines(file_lines)
+  word_count = count_words(file_lines)
+  bytesize = count_bytesize(file_lines)
+
+  unless total_prop_count.nil?
+    total_prop_count[:line_count] += line_count
+    total_prop_count[:word_count] += word_count
+    total_prop_count[:bytesize] += bytesize
+  end
+
+  { line_count:, word_count:, bytesize: }
 end
 
 def count_lines(lines)

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -16,22 +16,20 @@ def print_from_stdin(options)
   lines_num = count_lines(input_data_lines)
   words_num = count_words(input_data_lines)
   file_size = count_bytesize(input_data_lines)
-  total_nums = { 'total_lines' => lines_num, 'total_words' => words_num, 'total_size' => file_size }
 
-  print_total(total_nums, options)
-  print "\n"
+  lines_words_sizes = [{ 'lines_num' => lines_num, 'words_num' => words_num, 'file_size' => file_size, 'file_name' => '' }]
+  width = [lines_num, words_num, file_size].max.to_s.size
+  width = width + 1 > DEFAULT_WIDTH ? width + 1 : DEFAULT_WIDTH
+
+  print_info(lines_words_sizes, width, options)
 end
 
 def print_from_args(files, options)
   files_info = format_files_info(files)
 
-  if files.size > 1
-    print_info(files_info[:lines_words_sizes], files_info[:total_nums], options)
-    print_total(files_info[:total_nums], options)
-    print " total\n"
-  else
-    print_info(files_info[:lines_words_sizes], files_info[:total_nums], options)
-  end
+  width = calc_width(files_info[:total_nums])
+  print_info(files_info[:lines_words_sizes], width, options)
+  print_total(files_info[:total_nums], width, options) if files.size > 1
 end
 
 def format_files_info(files)
@@ -48,15 +46,15 @@ def format_files_info(files)
 
   lines_words_sizes = [lines_nums, words_nums, file_sizes, files].transpose
   lines_words_sizes_keys = %w[lines_num words_num file_size file_name]
-  formatted_3_elemetnts_info =
+  formatted_3_elements_info =
     lines_words_sizes.map { |file_info| [lines_words_sizes_keys, file_info].transpose.to_h }
 
   total_nums = [total_lines_nums, total_words_nums, total_size]
-  total_nums_keys = %w[total_lines total_words total_size]
+  total_nums_keys = %w[lines_num words_num file_size]
   formatted_total_nums = [total_nums_keys, total_nums].transpose.to_h
 
   {
-    lines_words_sizes: formatted_3_elemetnts_info,
+    lines_words_sizes: formatted_3_elements_info,
     total_nums: formatted_total_nums
   }
 end
@@ -80,27 +78,29 @@ def calc_width(nums)
   width + 1 > DEFAULT_WIDTH ? width + 1 : DEFAULT_WIDTH
 end
 
-def print_info(files, total_nums, options)
-  width = calc_width(total_nums)
+def print_info(files_data, width, options)
   output = ''
   is_option_none = options.values.none?
-  files.each do |file|
-    output += file['lines_num'].to_s.rjust(width) if options['l'] || is_option_none
-    output += file['words_num'].to_s.rjust(width) if options['w'] || is_option_none
-    output += file['file_size'].to_s.rjust(width) if options['c'] || is_option_none
-    output += " #{file['file_name']}\n"
+  files_data.each do |file_data|
+    output = arrange_each_file(output, file_data, width, options, is_option_none)
+    output += " #{file_data['file_name']}\n"
   end
   print output
 end
 
-def print_total(total_nums, options)
-  width = calc_width(total_nums)
+def print_total(total_nums, width, options)
   output = ''
   is_option_none = options.values.none?
-  output += total_nums['total_lines'].to_s.rjust(width) if options['l'] || is_option_none
-  output += total_nums['total_words'].to_s.rjust(width) if options['w'] || is_option_none
-  output += total_nums['total_size'].to_s.rjust(width) if options['c'] || is_option_none
+  output = arrange_each_file(output, total_nums, width, options, is_option_none)
+  output += " total\n"
   print output
+end
+
+def arrange_each_file(output, file_data, width, options, is_option_none)
+  output += file_data['lines_num'].to_s.rjust(width) if options['l'] || is_option_none
+  output += file_data['words_num'].to_s.rjust(width) if options['w'] || is_option_none
+  output += file_data['file_size'].to_s.rjust(width) if options['c'] || is_option_none
+  output
 end
 
 main

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -11,19 +11,27 @@ def main
 end
 
 def print_from_stdin(options)
-  input_data = $stdin.read
-  lines = input_data.split("\n")
+  File.open('ls_result', 'w') { |file| file.puts $stdin.read }
+  files_info = files_info(['ls_result'])
+  File.delete('ls_result')
 
-  lines_num = lines.size
-  words_num = lines.map { |line| line.split.size }.sum
-  file_size = input_data.bytesize
-  total_nums = [lines_num, words_num, file_size]
-
-  print_total(total_nums, options)
+  print_total(files_info[:total_nums], options)
   print "\n"
 end
 
 def print_from_args(files, options)
+  files_info = files_info(files)
+
+  if files.size > 1
+    print_info(files_info[:lines_words_sizes_info], files_info[:total_nums], options)
+    print_total(files_info[:total_nums], options)
+    print " total\n"
+  else
+    print_info(files_info[:lines_words_sizes_info], files_info[:total_nums], options)
+  end
+end
+
+def files_info(files)
   lines_nums = calc_lines_nums(files)
   total_lines_nums = lines_nums.sum
 
@@ -33,18 +41,10 @@ def print_from_args(files, options)
   file_sizes = calc_sizes(files)
   total_size = file_sizes.sum
 
-  total_nums = [total_lines_nums, total_words_nums, total_size]
-
-  files_info = [lines_nums, words_nums, file_sizes, files]
-  formatted_info = files_info.transpose
-
-  if files.size > 1
-    print_info(formatted_info, total_nums, options)
-    print_total(total_nums, options)
-    print " total\n"
-  else
-    print_info(formatted_info, total_nums, options)
-  end
+  {
+    lines_words_sizes_info: [lines_nums, words_nums, file_sizes, files].transpose,
+    total_nums: [total_lines_nums, total_words_nums, total_size]
+  }
 end
 
 def calc_lines_nums(files)

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -19,9 +19,7 @@ def print_from_stdin(options)
   file_size = input_data.bytesize
   total_nums = [lines_num, words_num, file_size]
 
-  width = calc_width(total_nums)
-
-  print_total(total_nums, width, options)
+  print_total(total_nums, options)
   print "\n"
 end
 
@@ -36,17 +34,16 @@ def print_from_args(files, options)
   total_size = file_sizes.sum
 
   total_nums = [total_lines_nums, total_words_nums, total_size]
-  width = calc_width(total_nums)
 
   files_info = [lines_nums, words_nums, file_sizes, files]
   formatted_info = files_info.transpose
 
   if files.size > 1
-    print_info(formatted_info, width, options)
-    print_total(total_nums, width, options)
+    print_info(formatted_info, total_nums, options)
+    print_total(total_nums, options)
     print " total\n"
   else
-    print_info(formatted_info, width, options)
+    print_info(formatted_info, total_nums, options)
   end
 end
 
@@ -83,7 +80,8 @@ def calc_width(nums)
   width + 1 > DEFAULT_WIDTH ? width + 1 : DEFAULT_WIDTH
 end
 
-def print_info(files, width, options)
+def print_info(files, total_nums, options)
+  width = calc_width(total_nums)
   output = ''
   is_option_none = options.values.none?
   files.each do |file|
@@ -95,7 +93,8 @@ def print_info(files, width, options)
   print output
 end
 
-def print_total(total_nums, width, options)
+def print_total(total_nums, options)
+  width = calc_width(total_nums)
   output = ''
   is_option_none = options.values.none?
   output += total_nums[0].to_s.rjust(width) if options['l'] || is_option_none

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -73,8 +73,7 @@ end
 
 def num_of_lines(lines)
   num_of_lines = lines.size
-  is_last_line_new_line = lines[-1] =~ /\n$/
-  num_of_lines -= 1 unless is_last_line_new_line
+  num_of_lines -= 1 unless lines.last.end_with?("\n")
   num_of_lines = 0 if lines.none?
   num_of_lines
 end

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -15,50 +15,41 @@ def print_pipelined_input(options)
 
   line_count = count_lines(input_data_lines)
   word_count = count_words(input_data_lines)
-  file_size = count_bytesize(input_data_lines)
+  bytesize = count_bytesize(input_data_lines)
 
-  input_data_properties = [{ line_count:, word_count:, file_size:, file_name: '' }]
+  input_data_props = [{ line_count:, word_count:, bytesize:, file_name: '' }]
 
-  print_files_own_properties(input_data_properties, options)
+  print_file_props(input_data_props, options)
 end
 
 def print_specified_files(files, options)
-  files_info = format_files_own_properties(files)
-
-  print_files_own_properties(files_info, options)
-end
-
-def format_files_own_properties(files)
-
-  formatted_files_own_properties_sets =
+  file_props =
     files.map do |file|
       file_lines = File.open(file, &:readlines)
       line_count = count_lines(file_lines)
       word_count = count_words(file_lines)
-      file_size = count_bytesize(file_lines)
-      file_name = file
-      { line_count:, word_count:, file_size:, file_name: }
+      bytesize = count_bytesize(file_lines)
+      { line_count:, word_count:, bytesize:, file_name: file }
     end
-  
+
   if files.size > 1
     line_count = 0
     word_count = 0
-    file_size = 0
-    file_name = 'total'
-    formatted_files_own_properties_sets.each do |file|
-      line_count += file[:line_count]
-      word_count += file[:word_count]
-      file_size += file[:file_size]
+    bytesize = 0
+    file_props.each do |file_prop|
+      line_count += file_prop[:line_count]
+      word_count += file_prop[:word_count]
+      bytesize += file_prop[:bytesize]
     end
-    formatted_files_own_properties_sets << { line_count:, word_count:, file_size:, file_name: }
+    file_props << { line_count:, word_count:, bytesize:, file_name: 'total' }
   end
 
-  formatted_files_own_properties_sets
+  print_file_props(file_props, options)
 end
 
 def count_lines(lines)
-  lines_num = lines.size
-  lines.none? || lines.last.end_with?("\n") ? lines_num : lines_num - 1
+  line_count = lines.size
+  lines.none? || lines.last.end_with?("\n") ? line_count : line_count - 1
 end
 
 def count_words(lines)
@@ -69,20 +60,20 @@ def count_bytesize(lines)
   lines.join.bytesize
 end
 
-def print_files_own_properties(files_properties, options)
-  files_properties.each do |file_properties|
-    output = arrange_output_line(file_properties, options)
-    puts output + " #{file_properties[:file_name]}"
+def print_file_props(file_props, options)
+  file_props.each do |file_prop|
+    arranged_output_line = arrange_output_line(file_prop, options)
+    puts arranged_output_line + " #{file_prop[:file_name]}"
   end
 end
 
-def arrange_output_line(properties, options)
+def arrange_output_line(file_prop, options)
   is_option_none = options.values.none?
-  output = ''
-  output += properties[:line_count].to_s.rjust(PRINTING_WIDTH) if options['l'] || is_option_none
-  output += properties[:word_count].to_s.rjust(PRINTING_WIDTH) if options['w'] || is_option_none
-  output += properties[:file_size].to_s.rjust(PRINTING_WIDTH) if options['c'] || is_option_none
-  output
+  output_line = ''
+  output_line += file_prop[:line_count].to_s.rjust(PRINTING_WIDTH) if options['l'] || is_option_none
+  output_line += file_prop[:word_count].to_s.rjust(PRINTING_WIDTH) if options['w'] || is_option_none
+  output_line += file_prop[:bytesize].to_s.rjust(PRINTING_WIDTH) if options['c'] || is_option_none
+  output_line
 end
 
 main

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -13,39 +13,35 @@ end
 def print_pipelined_input(options)
   stdin_lines = $stdin.readlines
 
-  stdin_prop = format_file_prop(stdin_lines)
-  stdin_prop[:file_name] = ''
+  stdin_props = count_file_props(stdin_lines)
+  stdin_props[:file_name] = ''
 
-  print_file_props([stdin_prop], options)
+  print_file_props_list([stdin_props], options)
 end
 
 def print_specified_files(files, options)
-  total_file_prop_count = { line_count: 0, word_count: 0, bytesize: 0, file_name: 'total' }
+  total = { line_count: 0, word_count: 0, bytesize: 0, file_name: 'total' }
 
-  file_props =
+  file_props_list =
     files.map do |file|
       file_lines = File.open(file, &:readlines)
-      file_prop = format_file_prop(file_lines, total_file_prop_count)
-      file_prop[:file_name] = file
-      file_prop
+      file_props = count_file_props(file_lines)
+      total[:line_count] += file_props[:line_count]
+      total[:word_count] += file_props[:word_count]
+      total[:bytesize] += file_props[:bytesize]
+      file_props[:file_name] = file
+      file_props
     end
 
-  file_props << total_file_prop_count if files.size > 1
+  file_props_list << total if files.size > 1
 
-  print_file_props(file_props, options)
+  print_file_props_list(file_props_list, options)
 end
 
-def format_file_prop(file_lines, total_file_prop_count = nil)
+def count_file_props(file_lines)
   line_count = count_lines(file_lines)
   word_count = count_words(file_lines)
   bytesize = count_bytesize(file_lines)
-
-  unless total_file_prop_count.nil?
-    total_file_prop_count[:line_count] += line_count
-    total_file_prop_count[:word_count] += word_count
-    total_file_prop_count[:bytesize] += bytesize
-  end
-
   { line_count:, word_count:, bytesize: }
 end
 
@@ -62,19 +58,19 @@ def count_bytesize(lines)
   lines.join.bytesize
 end
 
-def print_file_props(file_props, options)
-  file_props.each do |file_prop|
-    arranged_output_line = arrange_output_line(file_prop, options)
-    puts arranged_output_line + " #{file_prop[:file_name]}"
+def print_file_props_list(file_props_list, options)
+  file_props_list.each do |file_props|
+    arranged_output_line = arrange_output_line(file_props, options)
+    puts arranged_output_line + " #{file_props[:file_name]}"
   end
 end
 
-def arrange_output_line(file_prop, options)
+def arrange_output_line(file_props, options)
   is_option_none = options.values.none?
   output_line = ''
-  output_line += file_prop[:line_count].to_s.rjust(PRINTING_WIDTH) if options['l'] || is_option_none
-  output_line += file_prop[:word_count].to_s.rjust(PRINTING_WIDTH) if options['w'] || is_option_none
-  output_line += file_prop[:bytesize].to_s.rjust(PRINTING_WIDTH) if options['c'] || is_option_none
+  output_line += file_props[:line_count].to_s.rjust(PRINTING_WIDTH) if options['l'] || is_option_none
+  output_line += file_props[:word_count].to_s.rjust(PRINTING_WIDTH) if options['w'] || is_option_none
+  output_line += file_props[:bytesize].to_s.rjust(PRINTING_WIDTH) if options['c'] || is_option_none
   output_line
 end
 

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -14,10 +14,10 @@ def print_from_stdin
   input_data = $stdin.read
   lines = input_data.split("\n")
 
-  num_of_lines = lines.size.to_s
-  num_of_words = lines.map { |line| line.split.size }.sum.to_s
+  lines_num = lines.size.to_s
+  words_num = lines.map { |line| line.split.size }.sum.to_s
   file_size = input_data.bytesize.to_s
-  total_nums = [num_of_lines, num_of_words, file_size]
+  total_nums = [lines_num, words_num, file_size]
 
   width = calc_width(total_nums)
 
@@ -26,19 +26,19 @@ def print_from_stdin
 end
 
 def print_from_args(files)
-  nums_of_lines = calc_nums_of_lines(files)
-  total_nums_of_lines = nums_of_lines.sum.to_s
+  lines_nums = calc_lines_nums(files)
+  total_lines_nums = lines_nums.sum.to_s
 
-  nums_of_words = calc_nums_of_words(files)
-  total_nums_of_words = nums_of_words.sum.to_s
+  words_nums = calc_words_nums(files)
+  total_words_nums = words_nums.sum.to_s
 
   file_sizes = calc_sizes(files)
   total_size = file_sizes.sum.to_s
 
-  total_nums = [total_nums_of_lines, total_nums_of_words, total_size]
+  total_nums = [total_lines_nums, total_words_nums, total_size]
   width = calc_width(total_nums)
 
-  files_info = [nums_of_lines.map(&:to_s), nums_of_words.map(&:to_s), file_sizes.map(&:to_s), files]
+  files_info = [lines_nums.map(&:to_s), words_nums.map(&:to_s), file_sizes.map(&:to_s), files]
   formatted_info = files_info.transpose
 
   if files.size > 1
@@ -50,14 +50,14 @@ def print_from_args(files)
   end
 end
 
-def calc_nums_of_lines(files)
+def calc_lines_nums(files)
   files.map do |file|
     lines = File.open(file, &:readlines)
-    num_of_lines(lines)
+    lines_num(lines)
   end
 end
 
-def calc_nums_of_words(files)
+def calc_words_nums(files)
   files.map do |file|
     lines = File.open(file, &:readlines)
     lines.sum { |line| line.split.size }
@@ -71,11 +71,11 @@ def calc_sizes(files)
   end
 end
 
-def num_of_lines(lines)
-  num_of_lines = lines.size
-  num_of_lines -= 1 unless lines.last.end_with?("\n")
-  num_of_lines = 0 if lines.none?
-  num_of_lines
+def lines_num(lines)
+  lines_num = lines.size
+  lines_num -= 1 unless lines.last.end_with?("\n")
+  lines_num = 0 if lines.none?
+  lines_num
 end
 
 def calc_width(nums)

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -60,18 +60,18 @@ end
 
 def print_file_props_list(file_props_list, options)
   file_props_list.each do |file_props|
-    arranged_output_line = arrange_output_line(file_props, options)
-    puts arranged_output_line + " #{file_props[:file_name]}"
+    line = arrange_line(file_props, options)
+    puts line + " #{file_props[:file_name]}"
   end
 end
 
-def arrange_output_line(file_props, options)
+def arrange_line(file_props, options)
   is_option_none = options.values.none?
-  output_line = ''
-  output_line += file_props[:line_count].to_s.rjust(PRINTING_WIDTH) if options['l'] || is_option_none
-  output_line += file_props[:word_count].to_s.rjust(PRINTING_WIDTH) if options['w'] || is_option_none
-  output_line += file_props[:bytesize].to_s.rjust(PRINTING_WIDTH) if options['c'] || is_option_none
-  output_line
+  line = ''
+  line += file_props[:line_count].to_s.rjust(PRINTING_WIDTH) if options['l'] || is_option_none
+  line += file_props[:word_count].to_s.rjust(PRINTING_WIDTH) if options['w'] || is_option_none
+  line += file_props[:bytesize].to_s.rjust(PRINTING_WIDTH) if options['c'] || is_option_none
+  line
 end
 
 main

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -1,0 +1,108 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+
+DEFAULT_WIDTH = 8
+OPTIONS = ARGV.getopts('lwc')
+
+def main
+  ARGV.none? ? print_from_stdin : print_from_args(ARGV)
+end
+
+def print_from_stdin
+  input_data = $stdin.read
+  lines = input_data.split("\n")
+
+  num_of_lines = lines.size.to_s
+  num_of_words = lines.map { |line| line.split.size }.sum.to_s
+  file_size = input_data.bytesize.to_s
+  total_nums = [num_of_lines, num_of_words, file_size]
+
+  width = calc_width(total_nums)
+
+  print_total(total_nums, width)
+  print "\n"
+end
+
+def print_from_args(args)
+  nums_of_lines = calc_nums_of_lines(args)
+  total_nums_of_lines = nums_of_lines.sum.to_s
+
+  nums_of_words = calc_nums_of_words(args)
+  total_nums_of_words = nums_of_words.sum.to_s
+
+  file_sizes = calc_sizes(args)
+  total_size = file_sizes.sum.to_s
+
+  total_nums = [total_nums_of_lines, total_nums_of_words, total_size]
+  width = calc_width(total_nums)
+
+  files_info = [nums_of_lines.map(&:to_s), nums_of_words.map(&:to_s), file_sizes.map(&:to_s), args]
+  formatted_info = files_info.transpose
+
+  if args.size > 1
+    print_info(formatted_info, width)
+    print_total(total_nums, width)
+    print " total\n"
+  else
+    print_info(formatted_files, width)
+  end
+end
+
+def calc_nums_of_lines(files)
+  files.map do |file|
+    lines = File.open(file, &:readlines)
+    num_of_lines(lines)
+  end
+end
+
+def calc_nums_of_words(files)
+  files.map do |file|
+    lines = File.open(file, &:readlines)
+    lines.sum { |line| line.split.size }
+  end
+end
+
+def calc_sizes(files)
+  files.map do |file|
+    file_stat = File.stat(file)
+    file_stat.size
+  end
+end
+
+def num_of_lines(lines)
+  num_of_lines = lines.size
+  is_last_line_new_line = lines[-1] =~ /\n$/
+  num_of_lines -= 1 unless is_last_line_new_line
+  num_of_lines = 0 if lines.none?
+  num_of_lines
+end
+
+def calc_width(nums)
+  width = nums.map(&:size).max
+  width + 1 > DEFAULT_WIDTH ? width + 1 : DEFAULT_WIDTH
+end
+
+def print_info(files, width)
+  output = ''
+  is_option_none = OPTIONS.values.none?
+  files.each do |file|
+    output += file[0].rjust(width) if OPTIONS['l'] || is_option_none
+    output += file[1].rjust(width) if OPTIONS['w'] || is_option_none
+    output += file[2].rjust(width) if OPTIONS['c'] || is_option_none
+    output += " #{file[3]}\n"
+  end
+  print output
+end
+
+def print_total(total_nums, width)
+  output = ''
+  is_option_none = OPTIONS.values.none?
+  output += total_nums[0].rjust(width) if OPTIONS['l'] || is_option_none
+  output += total_nums[1].rjust(width) if OPTIONS['w'] || is_option_none
+  output += total_nums[2].rjust(width) if OPTIONS['c'] || is_option_none
+  print output
+end
+
+main


### PR DESCRIPTION
wcコマンドの課題を作成いたしました。
レビューのほど、何卒よろしくお願い致します🙇‍♂️

以下、補足です↓。

### 数値の表示幅について
`calc_width`というメソッドで取得した数値の表示幅を算出しています。
このコードでの数値の表示幅については、
- デフォルトでは「数字8桁分」の表示領域を確保
- 「指定したファイルの「行数」・「単語数」・「ファイルサイズ」の合計の中で、最も大きい数値の桁数が8桁を超える時」は、その桁数をもとに表示領域を確保

となるようになっています。

ただ、このロジックは`-l`と`-c`のオプションをつけた際にも適用されるため、
たとえばファイルサイズの合計だけが8桁より大きい場合、（ファイルサイズが表示されないにも関わらず）行数・単語数だけを表示するときもファイルサイズ分の表示領域が用意されます。

つまり、ファイルサイズが極端に大きく、かつ行数や単語数が少ないというファイル群を読み込むの場合、均等に表示はされるけれど空白が多いレイアウトになる、というケースがあります。

このあたり、最初の方針立ての段階で分岐の設定が甘かったと反省しており、かつ現時点ではちょっと手に負えずギブアップになっている感があります。。🙇‍♂️
ただ、本家wcコマンドのこのあたりまでの細かい表示ロジックが深掘りできておらず、また本プラクティスでどこまで突き詰めるべきか判断がつかないこともあり、一旦この状態で提出いたします。
もし対応すべきことや、よりよくなるところがあれば、ご指摘・ヒントを頂戴できれば幸いです🙇‍♂️

よろしくお願いいたします。